### PR TITLE
Warning fixes (Removed unnecessary arguments for several fields); Fix…

### DIFF
--- a/custom_addons/iot_certification/models/iot_certification_additional_order.py
+++ b/custom_addons/iot_certification/models/iot_certification_additional_order.py
@@ -41,7 +41,7 @@ class IoTCertificationAdditionalOrder(models.Model):
     
     safety_laboratory_id = fields.Many2one(
         comodel_name='iot_certification_testing_laboratory',
-        relation='safety_laboratory_id',
+    # relation='safety_laboratory_id',
         string='Випробувальна лабораторія:')
     
     safety_attachment_ids = fields.Many2many(
@@ -87,7 +87,7 @@ class IoTCertificationAdditionalOrder(models.Model):
     
     health_laboratory_id = fields.Many2one(
         comodel_name='iot_certification_testing_laboratory',
-        relation='health_laboratory_id',
+    # relation='health_laboratory_id',
         string='Випробувальна лабораторія:')
     
     health_attachment_ids = fields.Many2many(
@@ -133,7 +133,7 @@ class IoTCertificationAdditionalOrder(models.Model):
     
     emc_laboratory_id = fields.Many2one(
         comodel_name='iot_certification_testing_laboratory',
-        relation='emc_laboratory_id',
+    # relation='emc_laboratory_id',
         string='Випробувальна лабораторія:')
     
     emc_attachment_ids = fields.Many2many(
@@ -179,7 +179,7 @@ class IoTCertificationAdditionalOrder(models.Model):
     
     spectrum_laboratory_id = fields.Many2one(
         comodel_name='iot_certification_testing_laboratory',
-        relation='spectrum_laboratory_id',
+    # relation='spectrum_laboratory_id',
         string='Випробувальна лабораторія:')
     
     spectrum_attachment_ids = fields.Many2many(

--- a/custom_addons/iot_certification/models/iot_certification_order.py
+++ b/custom_addons/iot_certification/models/iot_certification_order.py
@@ -471,7 +471,7 @@ class IoTCertificationOrder(models.Model):
     
     safety_laboratory_id = fields.Many2one(
         comodel_name='iot_certification_testing_laboratory',
-        relation='safety_laboratory_id',
+    # relation='safety_laboratory_id',
         string='Випробувальна лабораторія:')
     
     safety_attachment_ids = fields.Many2many(
@@ -507,7 +507,7 @@ class IoTCertificationOrder(models.Model):
     
     health_laboratory_id = fields.Many2one(
         comodel_name='iot_certification_testing_laboratory',
-        relation='health_laboratory_id',
+    # relation='health_laboratory_id',
         string='Випробувальна лабораторія:')
     
     health_attachment_ids = fields.Many2many(
@@ -543,7 +543,7 @@ class IoTCertificationOrder(models.Model):
     
     emc_laboratory_id = fields.Many2one(
         comodel_name='iot_certification_testing_laboratory',
-        relation='emc_laboratory_id',
+    # relation='emc_laboratory_id',
         string='Випробувальна лабораторія:')
     
     emc_attachment_ids = fields.Many2many(
@@ -579,7 +579,7 @@ class IoTCertificationOrder(models.Model):
     
     spectrum_laboratory_id = fields.Many2one(
         comodel_name='iot_certification_testing_laboratory',
-        relation='spectrum_laboratory_id',
+    # relation='spectrum_laboratory_id',
         string='Випробувальна лабораторія:')
     
     spectrum_attachment_ids = fields.Many2many(
@@ -844,7 +844,7 @@ class IoTCertificationOrder(models.Model):
             index2 = 21 - index
             show_condition_field = getattr(self, f'show_condition_{index2}')
             if show_condition_field:
-                setattr(self, f'condition_{index2}_verdict', 'no')
+                setattr(self, f'condition_{index2}_verd', 'no')
                 setattr(self, f'condition_{index2}_notes', '')
                 setattr(self, f'condition_{index2}_attachment_ids', False)
                 setattr(self, f'show_condition_{index2}', False)

--- a/custom_addons/iot_certification/models/iot_certification_testing_laboratory.py
+++ b/custom_addons/iot_certification/models/iot_certification_testing_laboratory.py
@@ -10,7 +10,7 @@ class TestingLaboratory(models.Model):
     
     order_no = fields.Many2one(
         comodel_name='iot_certification_order',
-        inverse_name='safety_laboratory_id',
+    # inverse_name='safety_laboratory_id',
         string='Номер')
     
     


### PR DESCRIPTION
…ed error in the delete_last_condition function in the iot_certification_order.py file (wrong field name)

Description of the issue/feature this PR addresses:
When deleting the last condition (see custom_addons/iot_certification/models/iot_certification_order.py:842) there was wrong variable naming, so the bug was occurring.
Also, there were a lot of warnings due to unnecessary arguments in several fields.

Current behavior before PR:
An exception occurs when deleting the last condition in the form, a lot of warnings when starting the odoo server.

Desired behavior after PR is merged:
There's no exception when deleting the last condition, a lot of warnings are gone



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
