### PR TITLE
Made iot_certification_order module fields and iot_certification_orde…

### DIFF
--- a/custom_addons/iot_certification/models/iot_certification_order.py
+++ b/custom_addons/iot_certification/models/iot_certification_order.py
@@ -140,6 +140,9 @@ class IoTCertificationOrder(models.Model):
     
     product_specification_1_8 = fields.Boolean(
         string="ZigBee")
+
+    product_specification_1_9 = fields.Boolean(
+        string="2400 МГц")
     
     product_specification_2 = fields.Boolean(
         string="Цифровий стільниковий радіозв'язок")
@@ -170,9 +173,21 @@ class IoTCertificationOrder(models.Model):
     
     product_specification_3_4 = fields.Boolean(
         string="5800 МГц")
+
+    product_specification_3_5 = fields.Boolean(
+        string="6,7 МГц")
+
+    product_specification_3_6 = fields.Boolean(
+        string="13 МГц")
     
     product_specification_4 = fields.Boolean(
-        string="Індуктивні застосування (NFC)")
+        string="Індуктивні застосування")
+
+    product_specification_4_1 = fields.Boolean(
+        string="NFC")
+
+    product_specification_4_2 = fields.Boolean(
+        string="RFID")
     
     product_specification_5 = fields.Boolean(
         string="Приймач")
@@ -184,16 +199,19 @@ class IoTCertificationOrder(models.Model):
         string="FM")
     
     product_specification_5_3 = fields.Boolean(
-        string="TV/DBV")
-    
+        string="КХ/УКХ")
+
     product_specification_5_4 = fields.Boolean(
+        string="433 МГц")
+    
+    product_specification_5_5 = fields.Boolean(
         string="Інший")
     
-    product_specification_5_5 = fields.Text(
+    product_specification_5_6 = fields.Text(
         string="Інший (вказати)")
     
-    product_specification_6 = fields.Boolean(
-        string="УКХ радіозв'язок")
+    # product_specification_6 = fields.Boolean(
+    #     string="УКХ радіозв'язок")
     
     product_specification_7 = fields.Boolean(
         string="Радіолокаційні вимірювання")
@@ -205,10 +223,10 @@ class IoTCertificationOrder(models.Model):
         string="Радіорелейний зв'язок")
     
     product_specification_10 = fields.Boolean(
-        string="Інше")
+        string="Інше (функція безпроводового заряджання)")
     
-    product_specification_10_1 = fields.Text(
-        string="Інше (вказати)")
+    # product_specification_10_1 = fields.Text(
+    #     string="Інше (вказати)")
     
     product_specification_attachment_ids = fields.Many2many(
         comodel_name='ir.attachment',
@@ -755,7 +773,8 @@ class IoTCertificationOrder(models.Model):
             self.product_specification_1_6 = False
             self.product_specification_1_7 = False
             self.product_specification_1_8 = False
-    
+            self.product_specification_1_9 = False
+
     @api.onchange('product_specification_2')
     def _onchange_product_specification_2(self):
         if not self.product_specification_2:
@@ -771,7 +790,16 @@ class IoTCertificationOrder(models.Model):
             self.product_specification_3_2 = False
             self.product_specification_3_3 = False
             self.product_specification_3_4 = False
-    
+            self.product_specification_3_5 = False
+            self.product_specification_3_6 = False
+
+
+    @api.onchange('product_specification_4')
+    def _onchange_product_specification_4(self):
+        if not self.product_specification_4:
+            self.product_specification_4_1 = False
+            self.product_specification_4_2 = False
+
     @api.onchange('product_specification_5')
     def _onchange_product_specification_5(self):
         if not self.product_specification_5:
@@ -779,17 +807,18 @@ class IoTCertificationOrder(models.Model):
             self.product_specification_5_2 = False
             self.product_specification_5_3 = False
             self.product_specification_5_4 = False
-            self.product_specification_5_5 = ""
+            self.product_specification_5_5 = False
+            self.product_specification_5_6 = ""
     
-    @api.onchange('product_specification_5_4')
-    def _onchange_product_specification_5_4(self):
-        if not self.product_specification_5_4:
-            self.product_specification_5_5 = ""
+    @api.onchange('product_specification_5_5')
+    def _onchange_product_specification_5_5(self):
+        if not self.product_specification_5_5:
+            self.product_specification_5_6 = ""
     
-    @api.onchange('product_specification_10')
-    def _onchange_product_specification_10(self):
-        if not self.product_specification_10:
-            self.product_specification_10_1 = ""
+    # @api.onchange('product_specification_10')
+    # def _onchange_product_specification_10(self):
+    #     if not self.product_specification_10:
+    #         self.product_specification_10_1 = ""
     
     @api.onchange('the_scheme_of_power_supply_2')
     def _onchange_the_scheme_of_power_supply_2(self):

--- a/custom_addons/iot_certification/views/iot_certification_order_view.xml
+++ b/custom_addons/iot_certification/views/iot_certification_order_view.xml
@@ -120,7 +120,8 @@
                                             <field name="product_specification_1_6" attrs="{'invisible': [('product_specification_1', '=', False)]}"/>
                                             <field name="product_specification_1_7" attrs="{'invisible': [('product_specification_1', '=', False)]}"/>
                                             <field name="product_specification_1_8" attrs="{'invisible': [('product_specification_1', '=', False)]}"/>
-                                        </group> 
+                                            <field name="product_specification_1_9" attrs="{'invisible': [('product_specification_1', '=', False)]}"/>
+                                        </group>
                                     </group> 
                                     
                                     <group name="certification_header_details_tgn_product_specification_evidence_2" colspan="2">
@@ -144,6 +145,8 @@
                                             <field name="product_specification_3_2" attrs="{'invisible': [('product_specification_3', '=', False)]}"/>
                                             <field name="product_specification_3_3" attrs="{'invisible': [('product_specification_3', '=', False)]}"/>
                                             <field name="product_specification_3_4" attrs="{'invisible': [('product_specification_3', '=', False)]}"/>
+                                            <field name="product_specification_3_5" attrs="{'invisible': [('product_specification_3', '=', False)]}"/>
+                                            <field name="product_specification_3_6" attrs="{'invisible': [('product_specification_3', '=', False)]}"/>
                                         </group>
                                     </group> 
                                     
@@ -152,6 +155,8 @@
                                             <field name="product_specification_4"/>
                                         </group>
                                         <group name="certification_header_details_tgn_product_specification_evidence_42" colspan="1">
+                                            <field name="product_specification_4_1" attrs="{'invisible': [('product_specification_4', '=', False)]}"/>
+                                            <field name="product_specification_4_2" attrs="{'invisible': [('product_specification_4', '=', False)]}"/>
                                         </group>
                                     </group> 
                                     
@@ -164,17 +169,10 @@
                                             <field name="product_specification_5_2" attrs="{'invisible': [('product_specification_5', '=', False)]}"/>
                                             <field name="product_specification_5_3" attrs="{'invisible': [('product_specification_5', '=', False)]}"/>
                                             <field name="product_specification_5_4" attrs="{'invisible': [('product_specification_5', '=', False)]}"/>
-                                            <field name="product_specification_5_5" attrs="{'invisible': [('product_specification_5_4', '=', False)]}"/>
+                                            <field name="product_specification_5_5" attrs="{'invisible': [('product_specification_5', '=', False)]}"/>
+                                            <field name="product_specification_5_6" attrs="{'invisible': [('product_specification_5_5', '=', False)]}"/>
                                         </group>
-                                    </group> 
-                                    
-                                    <group name="certification_header_details_tgn_product_specification_evidence_6" colspan="2">
-                                        <group name="certification_header_details_tgn_product_specification_evidence_61" colspan="1">
-                                            <field name="product_specification_6"/>
-                                        </group>
-                                        <group name="certification_header_details_tgn_product_specification_evidence_62" colspan="1">
-                                        </group>
-                                    </group> 
+                                    </group>
                                     
                                     <group name="certification_header_details_tgn_product_specification_evidence_7" colspan="2">
                                         <group name="certification_header_details_tgn_product_specification_evidence_71" colspan="1">
@@ -201,7 +199,7 @@
                                     </group> 
                                     <group name="certification_header_details_tgn_product_specification_evidence_10" colspan="1" style="width:100%%">
                                         <field name="product_specification_10"/>
-                                        <field name="product_specification_10_1" attrs="{'invisible': [('product_specification_10', '=', False)]}"/>
+<!--                                        <field name="product_specification_10_1" attrs="{'invisible': [('product_specification_10', '=', False)]}"/>-->
                                     </group> 
                                 </group>
                                 <group name="certification_header_details_tgn_product_specification_attachments" style="width:40%%" colspan="1">


### PR DESCRIPTION
…r_view form view according to the application report example item 2.4

Description of the issue/feature this PR addresses:
Fields for item 2.4 of iot_certification_order module aren't the same as in the application report example.

Current behavior before PR:
the iot_certifacation has wrong fields for item 2.4 in the form for application report making.

Desired behavior after PR is merged:
the form has fixed fields for item 2.4, so the item 2.4 in the application report table can be filled properly.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
