### PR TITLE
Added buttons in xml and python

### DIFF
--- a/custom_addons/iot_certification/models/iot_certification_order.py
+++ b/custom_addons/iot_certification/models/iot_certification_order.py
@@ -1013,9 +1013,30 @@ class IoTCertificationOrder(models.Model):
             'type': 'ir.actions.client',
             'tag': 'reload',
         }
+
+    # def print_options(self):
+    #     return {
+    #         'res_model': 'res.partner',
+    #         'type': 'ir.actions.act_window',
+    #         'view_mode': 'form',
+    #         'view_id': self.env.ref('base.view_empty_form').id
+    #     }
+
+    def print_application(self):
+        return self.env.ref('iot_certification.iot_application_report_action').report_action(self)
+
     def print_report(self):
         for record in self:
             if not record.approved_report_status:
-                raise exceptions.ValidationError('Помилка: звіт неможливо надрукувати. Заявку не підтверджено керівником')
+                raise exceptions.ValidationError('Помилка: звіт неможливо надрукувати. Заявку не підтверджено відповідним керівником')
             else:
-                 return self.env.ref('iot_certification.iot_application_report_action').report_action(self)
+                 return self.env.ref('iot_certification.action_report').report_action(self)
+
+    def print_cert(self):
+        pass
+        # for record in self:
+        #     if not record.approved_cert_status:
+        #         raise exceptions.ValidationError('Помилка: сертифікат неможливо надрукувати. Заявку не підтверджено відповідним керівником')
+        #     else:
+        #          return self.env.ref('iot_certification.action_report').report_action(self)
+

--- a/custom_addons/iot_certification/views/iot_certification_order_view.xml
+++ b/custom_addons/iot_certification/views/iot_certification_order_view.xml
@@ -4,6 +4,7 @@
         <field name="res_model">iot_certification_report_for</field>
         <field name="view_mode">tree,form</field>
     </record>
+
     <record id="action_open_iot_certification_assessment" model="ir.actions.act_window">
         <field name="name">Open IoT Certification Assessments</field>
         <field name="res_model">iot_certification_assessment</field>
@@ -15,6 +16,9 @@
         <field name="model">iot_certification_order</field>
         <field name="arch" type="xml">
             <tree string="Замовлення на сертифікацію">
+<!--                <button name="print_report" type="object" icon="fa-solid fa-print"-->
+<!--                        string="Надрукувати"-->
+<!--                        groups="iot_certification.group_certification_report_manager, iot_certification.group_certification_cert_manager"/>-->
                 <button name="copy_record_and_update_name" string="Копіювати" type="object"/>
                 <field name="name" string="Реєстраційний номер" decoration-bf="1"/>
                 <field name="responsible_person" widget="many2one_avatar_user"/>
@@ -33,10 +37,16 @@
         <field name="name">iot_certification_order.form</field>
         <field name="model">iot_certification_order</field>
         <field name="arch" type="xml">
-            <form string="Замовлення на сертифікацію" attrs="{'readonly': [('status', 'in', ('approved'))]}">
+            <form string="Замовлення на сертифікацію" attrs="{'readonly': [('status', '=', ('approved'))]}">
                 <header>
+                    <button name="print_application" type="object" icon="fa-solid fa-print" class="oe_highlight"
+                            string="Друк заявки"
+                            groups="iot_certification.group_certification_report_manager, iot_certification.group_certification_cert_manager"/>
                     <button name="print_report" type="object" icon="fa-solid fa-print" class="oe_highlight"
-                            string="Надрукувати"
+                            string="Друк звіту"
+                            groups="iot_certification.group_certification_report_manager, iot_certification.group_certification_cert_manager"/>
+                    <button name="print_cert" type="object" icon="fa-solid fa-print" class="oe_highlight"
+                            string="Друк сертифікату"
                             groups="iot_certification.group_certification_report_manager, iot_certification.group_certification_cert_manager"/>
                     <field name="status" widget="statusbar"/>
                 </header>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Incomplete working functionality 
Current behavior before PR:
User can only use print application button
Desired behavior after PR is merged:
User can operate diff buttons to print application or report(also cert but in has pass python function)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
