### PR TITLE
added sales module dependence, view_res_partner_form_extension view changes

### DIFF
--- a/custom_addons/iot_certification/__manifest__.py
+++ b/custom_addons/iot_certification/__manifest__.py
@@ -5,7 +5,8 @@
     'depends': [
         'base',
         'product',
-        'mail'
+        'mail',
+        'sale_management'
     ],
     'data': [
         # iot security related

--- a/custom_addons/iot_certification/views/iot_certification_partner.xml
+++ b/custom_addons/iot_certification/views/iot_certification_partner.xml
@@ -1,13 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <record id="view_res_partner_form_extension" model="ir.ui.view">
         <field name="name">iot.res.partner.form.inherit</field>
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form"/>
         <field name="arch" type="xml">
+            <xpath expr="//button[@name='action_view_sale_order']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath expr="//button[@name='action_view_partner_invoices']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+
             <xpath expr="//notebook" position="replace">
                 <group>
-                    <field name="user_id"/>
-                    <field name="team_id"/>
+                    <field name="user_id" invisible="1"/>
+                    <field name="team_id" invisible="1"/>
                     <field name="duplicated_bank_account_partners_count" attrs="{'invisible': True }"/>
                     <h2>Тип партнера</h2>
                     <field name="partner_type" string="" widget="html_select"/>


### PR DESCRIPTION
added sales module dependence in __manifest__.py file. view_res_partner_form_extension view changes: user_id and team_id fields now invisible; sales and invoice stats are deleted now.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
